### PR TITLE
Build setspec and dissterms instances in servlet init.

### DIFF
--- a/src/main/java/proai/cache/Updater.java
+++ b/src/main/java/proai/cache/Updater.java
@@ -39,12 +39,13 @@ import org.slf4j.LoggerFactory;
 
 import net.sf.bvalid.Validator;
 import oaiprovider.FedoraSetInfo;
+import oaiprovider.mappings.ListSetConfJson;
 import proai.MetadataFormat;
 import proai.Record;
 import proai.SetInfo;
 import proai.driver.OAIDriver;
 import proai.driver.RemoteIterator;
-import proai.driver.impl.SetSpecImpl;
+import proai.driver.daos.json.SetSpecDaoJson;
 import proai.error.ImmediateShutdownException;
 import proai.error.RepositoryException;
 import proai.error.ServerException;
@@ -657,8 +658,6 @@ public class Updater extends Thread {
 
         logger.debug("Updating sets...");
 
-        SetSpecImpl setSpecMerge = new SetSpecImpl();
-
         // apply new / updated
         RemoteIterator<? extends SetInfo> riter = _driver.listSetInfo();
         Set<SetInfo> setInfos = new HashSet<>();
@@ -678,11 +677,10 @@ public class Updater extends Thread {
         }
 
         // add sets from json config
-        for (int i = 0; i < setSpecMerge.getSetSpecsConf().size(); i++) {
-            oaiprovider.mappings.ListSetConfJson.Set setObj = setSpecMerge.getSetSpecsConf().get(i);
+        for (ListSetConfJson.Set set : ((SetSpecDaoJson) _driver.getProps().get("dynSetSpecs")).getSetObjects()) {
             FedoraSetInfo fedoraSetInfo = new FedoraSetInfo();
-            fedoraSetInfo.setSpec(setObj.getSetSpec());
-            fedoraSetInfo.setName(setObj.getSetName());
+            fedoraSetInfo.setSpec(set.getSetSpec());
+            fedoraSetInfo.setName(set.getSetName());
             setInfos.add(fedoraSetInfo);
         }
 

--- a/src/main/java/proai/cache/Worker.java
+++ b/src/main/java/proai/cache/Worker.java
@@ -16,15 +16,23 @@
 
 package proai.cache;
 
-import net.sf.bvalid.Validator;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import proai.driver.OAIDriver;
-import proai.util.StreamUtil;
-
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.Iterator;
 import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import net.sf.bvalid.Validator;
+import proai.driver.OAIDriver;
+import proai.util.StreamUtil;
 
 public class Worker extends Thread {
 
@@ -52,6 +60,7 @@ public class Worker extends Thread {
         _validator = validator;
     }
 
+    @Override
     public void run() {
 
         _LOG.info("Worker started");

--- a/src/main/java/proai/driver/OAIDriver.java
+++ b/src/main/java/proai/driver/OAIDriver.java
@@ -16,15 +16,15 @@
 
 package proai.driver;
 
+import java.io.PrintWriter;
+import java.util.Date;
+import java.util.Properties;
+
 import proai.MetadataFormat;
 import proai.Record;
 import proai.SetInfo;
 import proai.Writable;
 import proai.error.RepositoryException;
-
-import java.io.PrintWriter;
-import java.util.Date;
-import java.util.Properties;
 
 /**
  * An interface to a repository.
@@ -46,6 +46,13 @@ public interface OAIDriver extends Writable {
     void init(Properties props) throws RepositoryException;
 
     /**
+     * Returns application properties
+     *
+     * @return {@link Properties}
+     */
+    Properties getProps();
+
+    /**
      * Write information about the repository to the given PrintWriter.
      * <p/>
      * <p/>
@@ -57,6 +64,7 @@ public interface OAIDriver extends Writable {
      *
      * @throws RepositoryException if there is a problem reading from the repository.
      */
+    @Override
     void write(PrintWriter out) throws RepositoryException;
 
     /**

--- a/src/main/java/proai/driver/daos/json/DissTermsDaoJson.java
+++ b/src/main/java/proai/driver/daos/json/DissTermsDaoJson.java
@@ -1,4 +1,4 @@
-package proai.driver.impl;
+package proai.driver.daos.json;
 
 import java.io.File;
 import java.io.IOException;
@@ -19,10 +19,22 @@ import oaiprovider.mappings.DissTerms.DissTerm;
 import oaiprovider.mappings.DissTerms.Term;
 import oaiprovider.mappings.DissTerms.XmlNamspace;
 
-public class DissTermsImpl {
-    private static final Logger logger = LoggerFactory.getLogger(DissTermsImpl.class);
+public class DissTermsDaoJson {
+    private static final Logger logger = LoggerFactory.getLogger(DissTermsDaoJson.class);
 
-    private ObjectMapper om = new ObjectMapper();
+    DissTerms dissTerms = null;
+
+    public DissTermsDaoJson() {
+        ObjectMapper om = new ObjectMapper();
+        File file = new File(getClass().getClassLoader().getResource("config/dissemination-config.json").getPath());
+
+        try {
+            dissTerms = om.readValue(Files.readAllBytes(Paths.get(file.getAbsolutePath())), DissTerms.class);
+        } catch (IOException e) {
+            e.printStackTrace();
+            logger.debug("dissemination-conf parse failed.");
+        }
+    }
 
     public Map<String, String> getMapXmlNamespaces() {
         Map<String, String> map = new HashMap<>();
@@ -52,7 +64,7 @@ public class DissTermsImpl {
     }
 
     public Term getTerm(String diss, String name) {
-        HashSet<DissTerm> dissTerms = (HashSet<DissTerm>) dissTerms().getDissTerms();
+        HashSet<DissTerm> dissTerms = (HashSet<DissTerm>) this.dissTerms.getDissTerms();
         Term term = null;
 
         for (DissTerm dt : dissTerms) {
@@ -86,21 +98,7 @@ public class DissTermsImpl {
     }
 
     private Set<XmlNamspace> xmlNamespaces() {
-        HashSet<XmlNamspace> xmlNamespaces = (HashSet<XmlNamspace>) dissTerms().getXmlnamespacees();
+        HashSet<XmlNamspace> xmlNamespaces = (HashSet<XmlNamspace>) dissTerms.getXmlnamespacees();
         return xmlNamespaces;
-    }
-
-    private DissTerms dissTerms() {
-        File file = new File(getClass().getClassLoader().getResource("config/dissemination-config.json").getPath());
-        DissTerms dissTerms = null;
-
-        try {
-            dissTerms = om.readValue(Files.readAllBytes(Paths.get(file.getAbsolutePath())), DissTerms.class);
-            return dissTerms;
-        } catch (IOException e) {
-            e.printStackTrace();
-            logger.debug("dissemination-conf parse failed.");
-            return dissTerms;
-        }
     }
 }

--- a/src/main/java/proai/driver/daos/json/SetSpecDaoJson.java
+++ b/src/main/java/proai/driver/daos/json/SetSpecDaoJson.java
@@ -1,9 +1,12 @@
-package proai.driver.impl;
+package proai.driver.daos.json;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -17,16 +20,13 @@ import oaiprovider.mappings.ListSetConfJson.Set;
  * @author dseelig
  *
  */
-public class SetSpecImpl {
-    private ObjectMapper om = new ObjectMapper();
+public class SetSpecDaoJson {
+    private static final Logger logger = LoggerFactory.getLogger(SetSpecDaoJson.class);
 
-    /**
-     * set with setspec entries from json setspec config file
-     */
-    private java.util.Set setSpecs;
+    private List<Set> sets = null;
 
-    public List<Set> getSetSpecsConf() {
-        List<Set> sets = null;
+    public SetSpecDaoJson() {
+        ObjectMapper om = new ObjectMapper();
         File setSpecs = new File(this.getClass().getClassLoader().getResource("config/list-set-conf.json").getPath());
 
         try {
@@ -38,27 +38,34 @@ public class SetSpecImpl {
         } catch (IOException e) {
             e.printStackTrace();
         }
+    }
 
+    public List<Set> getSetObjects() {
         return sets;
     }
 
-    /**
-     * returns a setspec set object with setspec json config entries
-     *
-     * @return {@link java.util.Set}
-     */
-    public java.util.Set<String> getSetSpecs() {
-        setSpecs = new HashSet<>();
+    public Set getSetObject(String setSpec) {
+        Set setObj = null;
 
-        for (int i = 0; i < getSetSpecsConf().size(); i++) {
-            Set set = getSetSpecsConf().get(i);
+        for (Set obj : getSetObjects()) {
+
+            if (obj.getSetSpec().equals(setSpec)) {
+                obj = setObj;
+                break;
+            }
+        }
+
+        return setObj;
+    }
+
+    public java.util.Set<String> getSetSpecs() {
+        java.util.Set<String> setSpecs = new HashSet<String>();
+
+        for (int i = 0; i < getSetObjects().size(); i++) {
+            Set set = getSetObjects().get(i);
             setSpecs.add(set.getSetSpec());
         }
 
         return setSpecs;
-    }
-
-    public void setSetSpecs(java.util.Set<String> setSpecs) {
-        this.setSpecs = setSpecs;
     }
 }

--- a/src/main/java/proai/driver/impl/OAIDriverImpl.java
+++ b/src/main/java/proai/driver/impl/OAIDriverImpl.java
@@ -16,17 +16,25 @@
 
 package proai.driver.impl;
 
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.Properties;
+
 import proai.MetadataFormat;
 import proai.Record;
 import proai.SetInfo;
 import proai.driver.OAIDriver;
 import proai.driver.RemoteIterator;
 import proai.error.RepositoryException;
-
-import java.io.*;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.util.*;
 
 /**
  * An simple OAIDriver for testing/demonstration purposes.
@@ -58,6 +66,7 @@ public class OAIDriverImpl implements OAIDriver {
     private File m_identityFile;
     private File m_recordsDir;
     private File m_setsDir;
+    private Properties props;
 
     public OAIDriverImpl() {
     }
@@ -85,7 +94,9 @@ public class OAIDriverImpl implements OAIDriver {
         }
     }
 
+    @Override
     public void init(Properties props) throws RepositoryException {
+        this.props = props;
         String baseDir = props.getProperty(BASE_DIR_PROPERTY);
         if (baseDir == null) {
             throw new RepositoryException("Required property is not set: "
@@ -118,10 +129,12 @@ public class OAIDriverImpl implements OAIDriver {
         }
     }
 
+    @Override
     public void write(PrintWriter out) throws RepositoryException {
         writeFromFile(m_identityFile, out);
     }
 
+    @Override
     public Date getLatestDate() {
         DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH-mm-ss");
         long latest = 0;
@@ -143,16 +156,19 @@ public class OAIDriverImpl implements OAIDriver {
         return new Date(latest);
     }
 
+    @Override
     public RemoteIterator<MetadataFormat> listMetadataFormats() {
         return new RemoteIteratorImpl<>(
                 getMetadataFormatCollection().iterator());
     }
 
+    @Override
     public RemoteIterator<SetInfo> listSetInfo() {
         return new RemoteIteratorImpl<>(
                 getSetInfoCollection().iterator());
     }
 
+    @Override
     public RemoteIterator<Record> listRecords(Date from,
                                               Date until,
                                               String mdPrefix) {
@@ -162,6 +178,7 @@ public class OAIDriverImpl implements OAIDriver {
     }
 
     // In this case, sourceInfo is the full path to the source file.
+    @Override
     public void writeRecordXML(String itemID,
                                String mdPrefix,
                                String sourceInfo,
@@ -169,6 +186,11 @@ public class OAIDriverImpl implements OAIDriver {
 
         File file = new File(sourceInfo);
         writeFromFile(file, writer);
+    }
+
+    @Override
+    public Properties getProps() {
+        return props;
     }
 
     private Collection<Record> getRecordCollection(Date from,
@@ -251,5 +273,4 @@ public class OAIDriverImpl implements OAIDriver {
             throw new RepositoryException("Error getting metadata formats", e);
         }
     }
-
 }

--- a/src/main/java/proai/service/ProviderServlet.java
+++ b/src/main/java/proai/service/ProviderServlet.java
@@ -16,28 +16,36 @@
 
 package proai.service;
 
-import ch.qos.logback.classic.LoggerContext;
-import ch.qos.logback.classic.joran.JoranConfigurator;
-import ch.qos.logback.core.joran.spi.JoranException;
-import ch.qos.logback.core.util.StatusPrinter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import proai.error.BadArgumentException;
-import proai.error.BadVerbException;
-import proai.error.ProtocolException;
-import proai.error.ServerException;
-import proai.util.StreamUtil;
-
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import java.io.*;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintWriter;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.joran.JoranConfigurator;
+import ch.qos.logback.core.joran.spi.JoranException;
+import ch.qos.logback.core.util.StatusPrinter;
+import proai.driver.daos.json.DissTermsDaoJson;
+import proai.driver.daos.json.SetSpecDaoJson;
+import proai.error.BadArgumentException;
+import proai.error.BadVerbException;
+import proai.error.ProtocolException;
+import proai.error.ServerException;
+import proai.util.StreamUtil;
 
 public class ProviderServlet extends HttpServlet {
     static final long serialVersionUID = 1;
@@ -63,6 +71,7 @@ public class ProviderServlet extends HttpServlet {
      * This makes a best-effort attempt to properly close any resources
      * (db connections, threads, etc) that are being held.
      */
+    @Override
     public void destroy() {
         try {
             m_responder.close();
@@ -74,6 +83,7 @@ public class ProviderServlet extends HttpServlet {
     /**
      * Entry point for handling OAI requests.
      */
+    @Override
     @SuppressWarnings("unchecked")
     public void doGet(HttpServletRequest request,
                       HttpServletResponse response) {
@@ -204,6 +214,7 @@ public class ProviderServlet extends HttpServlet {
         }
     }
 
+    @Override
     public void init() throws ServletException {
         String s = firstOf(
                 System.getProperty("proai.home"),
@@ -221,14 +232,14 @@ public class ProviderServlet extends HttpServlet {
         }
 
         final Path proaiConfigPath = (proaiHomePath != null) ? proaiHomePath.resolve("config") : null;
-
         configureLogback(proaiConfigPath);
-
         final InputStream propertiesStream = getPropertiesInputStream(proaiConfigPath);
 
         try {
             Properties props = new Properties();
             props.load(propertiesStream);
+            props.put("dissTermsData", new DissTermsDaoJson());
+            props.put("dynSetSpecs", new SetSpecDaoJson());
             m_responder = new Responder(props);
             setStylesheetProperty(props);
         } catch (Exception e) {
@@ -236,6 +247,7 @@ public class ProviderServlet extends HttpServlet {
         }
     }
 
+    @Override
     public void doPost(HttpServletRequest request,
                        HttpServletResponse response) {
         doGet(request, response);

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -22,7 +22,7 @@
 
     <context-param>
         <param-name>proai.home</param-name>
-        <param-value>/opt/oaiprovider</param-value>
+        <param-value>/home/dseelig/opt/oaiprovider</param-value>
     </context-param>
 
     <servlet>

--- a/src/test/java/proai/DissTermsTest.java
+++ b/src/test/java/proai/DissTermsTest.java
@@ -5,10 +5,10 @@ import org.junit.Test;
 
 import oaiprovider.mappings.DissTerms.Term;
 import oaiprovider.mappings.DissTerms.XmlNamspace;
-import proai.driver.impl.DissTermsImpl;
+import proai.driver.daos.json.DissTermsDaoJson;
 
 public class DissTermsTest {
-    private DissTermsImpl dissTermsData = new DissTermsImpl();
+    private DissTermsDaoJson dissTermsData = new DissTermsDaoJson();
 
     @Test
     public void xmlNamespacesTest() {

--- a/src/test/java/proai/LoadConfigsTest.java
+++ b/src/test/java/proai/LoadConfigsTest.java
@@ -1,16 +1,14 @@
 package proai;
 
-import java.util.HashSet;
-
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import oaiprovider.mappings.DissTerms;
-import proai.driver.impl.SetSpecImpl;
+import proai.driver.daos.json.SetSpecDaoJson;
 
 public class LoadConfigsTest {
-    private SetSpecImpl setSpecMerge = new SetSpecImpl();
+    private SetSpecDaoJson setSpecMerge = new SetSpecDaoJson();
 
     private DissTerms dissTerms = new DissTerms();
 
@@ -23,7 +21,6 @@ public class LoadConfigsTest {
 
     @Test
     public void getSetSpecs() {
-        setSpecMerge.setSetSpecs(new HashSet<String>());
         setSpecMerge.getSetSpecs();
     }
 }


### PR DESCRIPTION
Remove impl classes and create dao json classes for load setspec and dissterms data.
Write instances in the properties object in the servlet init method.
Expand the OAIDriver interface with props getter.
Use props instances in the fedora oai driver and remove all impl class code.