### PR TITLE
CMR-342: Set Configuration for open_access-Set

### DIFF
--- a/src/main/resources/config/dissemination-config.json
+++ b/src/main/resources/config/dissemination-config.json
@@ -64,11 +64,11 @@
       "terms": [
         {
           "name": "xmetadissplus",
-          "term": ""
+          "term": "//xMetaDiss:xMetaDiss[not(dc:rights='info:eu-repo/semantics/restrictedAccess')]"
         },
         {
           "name": "oai_dc",
-          "term": ""
+          "term": "//oai_dc:dc[not(dc:rights='info:eu-repo/semantics/restrictedAccess')]"
         }
       ]
     },

--- a/src/main/resources/config/list-set-conf.json
+++ b/src/main/resources/config/list-set-conf.json
@@ -497,7 +497,7 @@
   {
     "setSpec": "doc-type:article",
     "setName": "Article",
-    "predicate": "xDocType=aricle"
+    "predicate": "xDocType=article"
   },
   {
     "setSpec": "doc-type:bachelorThesis",


### PR DESCRIPTION
Added XPaths for "open_access"-Set.
Also corrected typo for doc-type:article.
https://jira.slub-dresden.de/browse/CMR-342