### PR TITLE
Cmr 393: Fixed missing doc-type

### DIFF
--- a/src/main/java/proai/driver/daos/json/DissTermsDaoJson.java
+++ b/src/main/java/proai/driver/daos/json/DissTermsDaoJson.java
@@ -52,42 +52,46 @@ public class DissTermsDaoJson {
         return xmlNamspace;
     }
 
+    /**
+     *
+     * @param diss First part of predicate in list-set-conf.json (f.e. "xDocType")
+     * @param name Metadata-prefix (terms -> name in dissemination-config.json)
+     * @return Term Term object (metadata-prefix + XPath-Expression)
+     */
     public Term getTerm(String diss, String name) {
         HashSet<DissTerm> dissTerms = (HashSet<DissTerm>) this.dissTerms.getDissTerms();
         Term term = null;
+        boolean dissExists = false;
+        boolean termExists = false;
 
         for (DissTerm dt : dissTerms) {
 
-            if (!dt.getDiss().equals(diss)) {
-                logger.debug(diss + " is does not exists in dissemination-config.");
-                continue;
-            }
+            if (dt.getDiss().equals(diss)) {
+                dissExists |= true;
 
-            if (dt.getTerms().isEmpty()) {
-                logger.debug(diss + " has no terms config.");
-                continue;
-            }
+                if (!dt.getTerms().isEmpty()) {
 
-            for (Term t : dt.getTerms()) {
+                    for (Term t : dt.getTerms()) {
 
-                if (!t.getName().equals(name)) {
-                    logger.debug("The term name " + name + " is not available in dissemination " + diss);
-                    continue;
+                        if (t.getName().equals(name)) {
+                            termExists |= true;
+                            term = t;
+                            break;
+                        }
+                    }
                 }
-
-                term = t;
             }
-
-            if (term != null) {
-                break;
-            }
+        }
+        if (!dissExists) {
+            logger.debug(diss + " does not exist in dissemination-config.");
+        } else if (!termExists) {
+            logger.debug("The term name " + name + " is not available in dissemination " + diss);
         }
 
         return term;
     }
 
     private Set<XmlNamspace> xmlNamespaces() {
-        HashSet<XmlNamspace> xmlNamespaces = (HashSet<XmlNamspace>) dissTerms.getXmlnamespacees();
-        return xmlNamespaces;
+        return dissTerms.getXmlnamespacees();
     }
 }

--- a/src/main/resources/config/dissemination-config.json
+++ b/src/main/resources/config/dissemination-config.json
@@ -77,7 +77,7 @@
       "terms": [
         {
           "name": "xmetadissplus",
-          "term": "//xMetaDiss:xMetaDiss/dc:type[@xsi:type='dini,:PublType' and .='$val']"
+          "term": "//xMetaDiss:xMetaDiss/dc:type[@xsi:type='dini:PublType' and .='$val']"
         },
         {
           "name": "oai_dc",

--- a/src/main/resources/config/dissemination-config.json
+++ b/src/main/resources/config/dissemination-config.json
@@ -47,6 +47,19 @@
   ],
   "dissTerms": [
     {
+      "diss": "xDocType",
+      "terms": [
+        {
+          "name": "xmetadissplus",
+          "term": "//xMetaDiss:xMetaDiss/dc:type[@xsi:type='dini:PublType' and .='$val']"
+        },
+        {
+          "name": "oai_dc",
+          "term": "//oai_dc:dc/dc:type[.='$val']"
+        }
+      ]
+    },
+    {
       "diss": "xDDC",
       "terms": [
         {
@@ -55,7 +68,7 @@
         },
         {
           "name": "oai_dc",
-          "term": "//oai_dc:dc/dc:classification[.='info:eu-repo/classification/ddc/$val']"
+          "term": "//oai_dc:dc/dc:subject[.='info:eu-repo/classification/ddc/$val']"
         }
       ]
     },
@@ -69,19 +82,6 @@
         {
           "name": "oai_dc",
           "term": "//oai_dc:dc[not(dc:rights='info:eu-repo/semantics/restrictedAccess')]"
-        }
-      ]
-    },
-    {
-      "diss": "xDocType",
-      "terms": [
-        {
-          "name": "xmetadissplus",
-          "term": "//xMetaDiss:xMetaDiss/dc:type[@xsi:type='dini:PublType' and .='$val']"
-        },
-        {
-          "name": "oai_dc",
-          "term": "//oai_dc:dc/dc:type[.='$val']"
         }
       ]
     },

--- a/src/main/resources/config/list-set-conf.json
+++ b/src/main/resources/config/list-set-conf.json
@@ -1,5 +1,160 @@
 [
   {
+    "setSpec": "doc-type:annotation",
+    "setName": "Annotation",
+    "predicate": "xDocType=annotation"
+  },
+  {
+    "setSpec": "doc-type:article",
+    "setName": "Article",
+    "predicate": "xDocType=article"
+  },
+  {
+    "setSpec": "doc-type:bachelorThesis",
+    "setName": "BachelorThesis",
+    "predicate": "xDocType=bachelorThesis"
+  },
+  {
+    "setSpec": "doc-type:book",
+    "setName": "Book",
+    "predicate": "xDocType=book"
+  },
+  {
+    "setSpec": "doc-type:bookPart",
+    "setName": "BookPart",
+    "predicate": "xDocType=bookPart"
+  },
+  {
+    "setSpec": "doc-type:CarthographicMaterial",
+    "setName": "CarthographicMaterial",
+    "predicate": "xDocType=CarthographicMaterial"
+  },
+  {
+    "setSpec": "doc-type:conferenceObject",
+    "setName": "conferenceObject",
+    "predicate": "xDocType=conferenceObject"
+  },
+  {
+    "setSpec": "doc-type:contributionToPeriodical",
+    "setName": "ContributionToPeriodical",
+    "predicate": "xDocType=contributionToPeriodical"
+  },
+  {
+    "setSpec": "doc-type:CourseMaterial",
+    "setName": "CourseMaterial",
+    "predicate": "xDocType=CourseMaterial"
+  },
+  {
+    "setSpec": "doc-type:doctoralThesis",
+    "setName": "DoctoralThesis",
+    "predicate": "xDocType=doctoralThesis"
+  },
+  {
+    "setSpec": "doc-type:Image",
+    "setName": "Image",
+    "predicate": "xDocType=Image"
+  },
+  {
+    "setSpec": "doc-type:lecture",
+    "setName": "Lecture",
+    "predicate": "xDocType=lecture"
+  },
+  {
+    "setSpec": "doc-type:Manuscript",
+    "setName": "Manuscript",
+    "predicate": "xDocType=Manuscript"
+  },
+  {
+    "setSpec": "doc-type:masterThesis",
+    "setName": "MasterThesis",
+    "predicate": "xDocType=masterThesis"
+  },
+  {
+    "setSpec": "doc-type:MovingImage",
+    "setName": "MovingImage",
+    "predicate": "xDocType=MovingImage"
+  },
+  {
+    "setSpec": "doc-type:MusicalNotation",
+    "setName": "MusicalNotation",
+    "predicate": "xDocType=MusicalNotation"
+  },
+  {
+    "setSpec": "doc-type:Other",
+    "setName": "Other",
+    "predicate": "xDocType=Other"
+  },
+  {
+    "setSpec": "doc-type:patent",
+    "setName": "Patent",
+    "predicate": "xDocType=patent"
+  },
+  {
+    "setSpec": "doc-type:Periodical",
+    "setName": "Periodical",
+    "predicate": "xDocType=Periodical"
+  },
+  {
+    "setSpec": "doc-type:PeriodicalPart",
+    "setName": "PeriodicalPart",
+    "predicate": "xDocType=PeriodicalPart"
+  },
+  {
+    "setSpec": "doc-type:preprint",
+    "setName": "Preprint",
+    "predicate": "xDocType=preprint"
+  },
+  {
+    "setSpec": "doc-type:report",
+    "setName": "Report",
+    "predicate": "xDocType=report"
+  },
+  {
+    "setSpec": "doc-type:ResearchData",
+    "setName": "ResearchData",
+    "predicate": "xDocType=ResearchData"
+  },
+  {
+    "setSpec": "doc-type:review",
+    "setName": "Review",
+    "predicate": "xDocType=review"
+  },
+  {
+    "setSpec": "doc-type:Software",
+    "setName": "Software",
+    "predicate": "xDocType=Software"
+  },
+  {
+    "setSpec": "doc-type:Sound",
+    "setName": "Sound",
+    "predicate": "xDocType=Sound"
+  },
+  {
+    "setSpec": "doc-type:StillImage",
+    "setName": "StillImage",
+    "predicate": "xDocType=StillImage"
+  },
+  {
+    "setSpec": "doc-type:StudyThesis",
+    "setName": "StudyThesis",
+    "predicate": "xDocType=StudyThesis"
+  },
+  {
+    "setSpec": "doc-type:Text",
+    "setName": "Text",
+    "predicate": "xDocType=Text"
+  },
+  {
+    "setSpec": "doc-type:Website",
+    "setName": "Website",
+    "predicate": "xDocType=Website"
+  },
+  {
+    "setSpec": "doc-type:workingPaper",
+    "setName": "WorkingPaper",
+    "predicate": "xDocType=workingPaper"
+  },
+  {
     "setSpec": "has-source-swb:true",
     "setName": "All records with PPN",
     "predicate": "xSourceSwb=true"
@@ -488,161 +643,6 @@
     "setSpec": "ddc:990",
     "setName": "General history of other areas",
     "predicate": "xDDC=990"
-  },
-  {
-    "setSpec": "doc-type:annotation",
-    "setName": "Annotation",
-    "predicate": "xDocType=annotation"
-  },
-  {
-    "setSpec": "doc-type:article",
-    "setName": "Article",
-    "predicate": "xDocType=article"
-  },
-  {
-    "setSpec": "doc-type:bachelorThesis",
-    "setName": "BachelorThesis",
-    "predicate": "xDocType=bachelorThesis"
-  },
-  {
-    "setSpec": "doc-type:book",
-    "setName": "Book",
-    "predicate": "xDocType=book"
-  },
-  {
-    "setSpec": "doc-type:bookPart",
-    "setName": "BookPart",
-    "predicate": "xDocType=bookPart"
-  },
-  {
-    "setSpec": "doc-type:CarthographicMaterial",
-    "setName": "CarthographicMaterial",
-    "predicate": "xDocType=CarthographicMaterial"
-  },
-  {
-    "setSpec": "doc-type:conferenceObject",
-    "setName": "conferenceObject",
-    "predicate": "xDocType=conferenceObject"
-  },
-  {
-    "setSpec": "doc-type:contributionToPeriodical",
-    "setName": "ContributionToPeriodical",
-    "predicate": "xDocType=contributionToPeriodical"
-  },
-  {
-    "setSpec": "doc-type:CourseMaterial",
-    "setName": "CourseMaterial",
-    "predicate": "xDocType=CourseMaterial"
-  },
-  {
-    "setSpec": "doc-type:doctoralThesis",
-    "setName": "DoctoralThesis",
-    "predicate": "xDocType=doctoralThesis"
-  },
-  {
-    "setSpec": "doc-type:Image",
-    "setName": "Image",
-    "predicate": "xDocType=Image"
-  },
-  {
-    "setSpec": "doc-type:lecture",
-    "setName": "Lecture",
-    "predicate": "xDocType=lecture"
-  },
-  {
-    "setSpec": "doc-type:Manuscript",
-    "setName": "Manuscript",
-    "predicate": "xDocType=Manuscript"
-  },
-  {
-    "setSpec": "doc-type:masterThesis",
-    "setName": "MasterThesis",
-    "predicate": "xDocType=masterThesis"
-  },
-  {
-    "setSpec": "doc-type:MovingImage",
-    "setName": "MovingImage",
-    "predicate": "xDocType=MovingImage"
-  },
-  {
-    "setSpec": "doc-type:MusicalNotation",
-    "setName": "MusicalNotation",
-    "predicate": "xDocType=MusicalNotation"
-  },
-  {
-    "setSpec": "doc-type:Other",
-    "setName": "Other",
-    "predicate": "xDocType=Other"
-  },
-  {
-    "setSpec": "doc-type:patent",
-    "setName": "Patent",
-    "predicate": "xDocType=patent"
-  },
-  {
-    "setSpec": "doc-type:Periodical",
-    "setName": "Periodical",
-    "predicate": "xDocType=Periodical"
-  },
-  {
-    "setSpec": "doc-type:PeriodicalPart",
-    "setName": "PeriodicalPart",
-    "predicate": "xDocType=PeriodicalPart"
-  },
-  {
-    "setSpec": "doc-type:preprint",
-    "setName": "Preprint",
-    "predicate": "xDocType=preprint"
-  },
-  {
-    "setSpec": "doc-type:report",
-    "setName": "Report",
-    "predicate": "xDocType=report"
-  },
-  {
-    "setSpec": "doc-type:ResearchData",
-    "setName": "ResearchData",
-    "predicate": "xDocType=ResearchData"
-  },
-  {
-    "setSpec": "doc-type:review",
-    "setName": "Review",
-    "predicate": "xDocType=review"
-  },
-  {
-    "setSpec": "doc-type:Software",
-    "setName": "Software",
-    "predicate": "xDocType=Software"
-  },
-  {
-    "setSpec": "doc-type:Sound",
-    "setName": "Sound",
-    "predicate": "xDocType=Sound"
-  },
-  {
-    "setSpec": "doc-type:StillImage",
-    "setName": "StillImage",
-    "predicate": "xDocType=StillImage"
-  },
-  {
-    "setSpec": "doc-type:StudyThesis",
-    "setName": "StudyThesis",
-    "predicate": "xDocType=StudyThesis"
-  },
-  {
-    "setSpec": "doc-type:Text",
-    "setName": "Text",
-    "predicate": "xDocType=Text"
-  },
-  {
-    "setSpec": "doc-type:Website",
-    "setName": "Website",
-    "predicate": "xDocType=Website"
-  },
-  {
-    "setSpec": "doc-type:workingPaper",
-    "setName": "WorkingPaper",
-    "predicate": "xDocType=workingPaper"
   },
   {
     "setSpec": "status-type:draftVersion",


### PR DESCRIPTION
Corrected Typo which was the reason for Set "doc-type" not showing.
Moved "doc-type"-Set-Configuration to the top, because WinIBW probably takes first Set showing as "Publikations-Typ". It's still not the first Set because of "static" Set "qucosa:slub".
Also reworked "DissTermsDaoJson.java" in order to give correct output on missing set-configurations.
https://jira.slub-dresden.de/browse/CMR-393