### PR TITLE
CMR-287: Configured openAire-Set and modified open_access-Set

### DIFF
--- a/src/main/java/oaiprovider/driver/FedoraOAIDriver.java
+++ b/src/main/java/oaiprovider/driver/FedoraOAIDriver.java
@@ -229,14 +229,14 @@ public class FedoraOAIDriver implements OAIDriver {
             xpathTerm = termExpression;
         }
 
-        Node node = null;
         try {
             XPathExpression xPathExpression = xPath.compile(xpathTerm);
-            node = (Node) xPathExpression.evaluate(document, XPathConstants.NODE);
+            return (boolean) xPathExpression.evaluate(document, XPathConstants.BOOLEAN);
         } catch (XPathExpressionException e) {
             logger.error(String.format("Cannot evaluate XPath expression >>>%s<<< : %s", xpathTerm, e.getMessage()));
         }
-        return (node != null);
+
+        return false;
     }
 
     static String getRequired(Properties props, String key)

--- a/src/main/java/oaiprovider/driver/FedoraOAIDriver.java
+++ b/src/main/java/oaiprovider/driver/FedoraOAIDriver.java
@@ -234,7 +234,7 @@ public class FedoraOAIDriver implements OAIDriver {
             XPathExpression xPathExpression = xPath.compile(xpathTerm);
             node = (Node) xPathExpression.evaluate(document, XPathConstants.NODE);
         } catch (XPathExpressionException e) {
-            logger.error(String.format("Cannot evaluate XPath expression '%s': %s", xPath, e.getMessage()));
+            logger.error(String.format("Cannot evaluate XPath expression >>>%s<<< : %s", xpathTerm, e.getMessage()));
         }
         return (node != null);
     }

--- a/src/main/resources/config/dissemination-config.json
+++ b/src/main/resources/config/dissemination-config.json
@@ -47,19 +47,6 @@
   ],
   "dissTerms": [
     {
-      "diss": "xDocType",
-      "terms": [
-        {
-          "name": "xmetadissplus",
-          "term": "//xMetaDiss:xMetaDiss/dc:type[@xsi:type='dini:PublType' and .='$val']"
-        },
-        {
-          "name": "oai_dc",
-          "term": "//oai_dc:dc/dc:type[.='$val']"
-        }
-      ]
-    },
-    {
       "diss": "xDDC",
       "terms": [
         {
@@ -68,7 +55,7 @@
         },
         {
           "name": "oai_dc",
-          "term": "//oai_dc:dc/dc:subject[.='info:eu-repo/classification/ddc/$val']"
+          "term": "//oai_dc:dc/dc:classification[.='info:eu-repo/classification/ddc/$val']"
         }
       ]
     },
@@ -77,11 +64,24 @@
       "terms": [
         {
           "name": "xmetadissplus",
-          "term": "//xMetaDiss:xMetaDiss[not(dc:rights='info:eu-repo/semantics/restrictedAccess')]"
+          "term": "//xMetaDiss:xMetaDiss[dc:rights='info:eu-repo/semantics/openAccess']"
         },
         {
           "name": "oai_dc",
-          "term": "//oai_dc:dc[not(dc:rights='info:eu-repo/semantics/restrictedAccess')]"
+          "term": "//oai_dc:dc[dc:rights='info:eu-repo/semantics/openAccess']"
+        }
+      ]
+    },
+    {
+      "diss": "xDocType",
+      "terms": [
+        {
+          "name": "xmetadissplus",
+          "term": "//xMetaDiss:xMetaDiss/dc:type[@xsi:type='dini:PublType' and .='$val']"
+        },
+        {
+          "name": "oai_dc",
+          "term": "//oai_dc:dc/dc:type='$val'"
         }
       ]
     },
@@ -90,11 +90,11 @@
       "terms": [
         {
           "name": "xmetadissplus",
-          "term": "//xMetaDiss:xMetaDiss/dini:version_driver[.='$val']"
+          "term": "//xMetaDiss:xMetaDiss/dini:version_driver='$val'"
         },
         {
           "name": "oai_dc",
-          "term": "//oai_dc:dc/dc:type[.='info:eu-repo/semantics/$val']"
+          "term": "//oai_dc:dc/dc:type='info:eu-repo/semantics/$val'"
         }
       ]
     },
@@ -103,11 +103,11 @@
       "terms": [
         {
           "name": "xmetadissplus",
-          "term": ""
+          "term": "//xMetaDiss:xMetaDiss[dc:rights='info:eu-repo/semantics/openAccess' or dc:relation='info:eu-repo/grantAgreement/*']"
         },
         {
           "name": "oai_dc",
-          "term": ""
+          "term": "//oai_dc:dc[dc:rights='info:eu-repo/semantics/openAccess' or dc:relation='info:eu-repo/grantAgreement/*']"
         }
       ]
     }

--- a/src/main/resources/config/list-set-conf.json
+++ b/src/main/resources/config/list-set-conf.json
@@ -671,6 +671,7 @@
   },
   {
     "setSpec": "openaire",
-    "predicate": "xOpenAire"
+    "setName": "OpenAire",
+    "predicate": "xOpenAire=openaire"
   }
 ]


### PR DESCRIPTION
Added XPath-Configuration for openAire.
Modified XPath for open-access to use the more "direct" approach.
https://jira.slub-dresden.de/browse/CMR-287