### PR TITLE
Add support for multiple set queries

### DIFF
--- a/src/main/java/proai/cache/RecordCache.java
+++ b/src/main/java/proai/cache/RecordCache.java
@@ -20,7 +20,11 @@ import net.sf.bvalid.SchemaLanguage;
 import net.sf.bvalid.Validator;
 import net.sf.bvalid.ValidatorFactory;
 import net.sf.bvalid.ValidatorOption;
-import net.sf.bvalid.catalog.*;
+import net.sf.bvalid.catalog.DiskSchemaCatalog;
+import net.sf.bvalid.catalog.FileSchemaIndex;
+import net.sf.bvalid.catalog.MemorySchemaCatalog;
+import net.sf.bvalid.catalog.SchemaCatalog;
+import net.sf.bvalid.catalog.SchemaIndex;
 import net.sf.bvalid.locator.CachingSchemaLocator;
 import net.sf.bvalid.locator.SchemaLocator;
 import net.sf.bvalid.locator.URLSchemaLocator;
@@ -41,7 +45,12 @@ import java.io.File;
 import java.io.InputStream;
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.*;
+import java.util.Date;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
 
 /**
  * Main application interface for working with items in the cache,
@@ -493,7 +502,7 @@ public class RecordCache extends Thread {
     public CloseableIterator<CachedContent> getRecordsContent(Date from,
                                                               Date until,
                                                               String prefix,
-                                                              String set,
+                                                              String[] set,
                                                               boolean identifiers) throws ServerException {
         if (until == null) {
             // If given as null, use the current date as from date.
@@ -518,7 +527,7 @@ public class RecordCache extends Thread {
     public CloseableIterator<String[]> getRecordsPaths(Date from,
                                                        Date until,
                                                        String prefix,
-                                                       String set) throws ServerException {
+                                                       String[] set) throws ServerException {
         if (until == null) {
             // If given as null, use the current date as from date.
             // This is done so that records with dates after the request date

--- a/src/main/java/proai/service/RecordListProvider.java
+++ b/src/main/java/proai/service/RecordListProvider.java
@@ -34,7 +34,7 @@ public class RecordListProvider implements ListProvider<CachedContent> {
     private final boolean m_identifiers;
     private final int m_incompleteListSize;
     private final String m_prefix;
-    private final String m_set;
+    private final String[] m_sets;
     private final Date m_until;
 
     public RecordListProvider(RecordCache cache,
@@ -43,14 +43,14 @@ public class RecordListProvider implements ListProvider<CachedContent> {
                               Date from,
                               Date until,
                               String prefix,
-                              String set) {
+                              String[] set) {
         m_cache = cache;
         m_incompleteListSize = incompleteListSize;
         m_identifiers = identifiers;
         m_from = from;
         m_until = until;
         m_prefix = prefix;
-        m_set = set;
+        m_sets = set;
     }
 
     public CloseableIterator<CachedContent> getList() throws
@@ -58,28 +58,28 @@ public class RecordListProvider implements ListProvider<CachedContent> {
         CloseableIterator<CachedContent> iter = m_cache.getRecordsContent(m_from,
                 m_until,
                 m_prefix,
-                m_set,
+                m_sets,
                 m_identifiers);
         if (iter.hasNext()) return iter;
         // else figure out why and throw the right exception
         if (m_cache.formatDoesNotExist(m_prefix)) {
             throw new CannotDisseminateFormatException();
         }
-        closeSetinfoIfNotNull(m_set);
+        if (m_sets != null) {
+            closeSetinfoIfNotNull();
+        }
         throw new NoRecordsMatchException();
     }
 
-    private void closeSetinfoIfNotNull(String mSet) {
-        if (mSet != null) {
-            CloseableIterator<SetInfo> sic = m_cache.getSetInfoContent();
-            boolean supportsSets = sic.hasNext();
-            try {
-                sic.close();
-            } catch (Exception ignored) {
-            }
-            if (!supportsSets) {
-                throw new NoSetHierarchyException();
-            }
+    private void closeSetinfoIfNotNull() {
+        CloseableIterator<SetInfo> sic = m_cache.getSetInfoContent();
+        boolean supportsSets = sic.hasNext();
+        try {
+            sic.close();
+        } catch (Exception ignored) {
+        }
+        if (!supportsSets) {
+            throw new NoSetHierarchyException();
         }
     }
 
@@ -88,13 +88,15 @@ public class RecordListProvider implements ListProvider<CachedContent> {
         CloseableIterator<String[]> iter = m_cache.getRecordsPaths(m_from,
                 m_until,
                 m_prefix,
-                m_set);
+                m_sets);
         if (iter.hasNext()) return iter;
         // else figure out why and throw the right exception
         if (m_cache.formatDoesNotExist(m_prefix)) {
             throw new CannotDisseminateFormatException();
         }
-        closeSetinfoIfNotNull(m_set);
+        if (m_sets != null) {
+            closeSetinfoIfNotNull();
+        }
         throw new NoRecordsMatchException();
     }
 

--- a/src/main/java/proai/service/Responder.java
+++ b/src/main/java/proai/service/Responder.java
@@ -86,6 +86,19 @@ public class Responder implements Closeable {
         }
     }
 
+    private static String q(String[] strings) {
+        if (strings == null) {
+            return null;
+        } else {
+            StringBuilder sb = new StringBuilder();
+            for (String s : strings) {
+                sb.append(q(s));
+                sb.append(" ");
+            }
+            return sb.toString().trim();
+        }
+    }
+
     /**
      * Throw a <code>BadArgumentException<code> if <code>identifier</code> is
      * <code>null</code> or empty.
@@ -210,7 +223,7 @@ public class Responder implements Closeable {
      * @param metadataPrefix  specifies that headers should be returned only if the metadata
      *                        format matching the supplied metadataPrefix is available (or
      *                        has been deleted).
-     * @param set             optional argument with a setSpec value, which specifies set
+     * @param sets             optional argument with a setSpec value, which specifies set
      *                        criteria for selective harvesting.
      * @param resumptionToken exclusive argument with a value that is the flow control token
      *                        returned by a previous ListIdentifiers request that issued an
@@ -228,7 +241,7 @@ public class Responder implements Closeable {
      * @throws ServerException                  if a low-level (non-protocol) error occurred.
      */
     public ResponseData listIdentifiers(String from, String until,
-                                        String metadataPrefix, String set, String resumptionToken)
+                                        String metadataPrefix, String[] sets, String resumptionToken)
             throws
             ServerException {
 
@@ -237,23 +250,23 @@ public class Responder implements Closeable {
         if (logger.isDebugEnabled()) {
             logger.debug(String.format(
                     "Entered listIdentifiers(%s, %s, %s, %s, %s)",
-                    q(from), q(until), q(metadataPrefix), q(set), q(resumptionToken)));
+                    q(from), q(until), q(metadataPrefix), q(sets), q(resumptionToken)));
         }
 
         try {
-            return listRecords(from, until, metadataPrefix, set,
+            return listRecords(from, until, metadataPrefix, sets,
                     resumptionToken, true, m_incompleteIdentifierListSize);
         } finally {
             if (logger.isDebugEnabled()) {
                 logger.debug(String.format(
                         "Exiting listIdentifiers(%s, %s, %s, %s, %s)",
-                        q(from), q(until), q(metadataPrefix), q(set), q(resumptionToken)));
+                        q(from), q(until), q(metadataPrefix), q(sets), q(resumptionToken)));
             }
         }
     }
 
     private ResponseData listRecords(String from, String until,
-                                     String metadataPrefix, String set, String resumptionToken,
+                                     String metadataPrefix, String[] sets, String resumptionToken,
                                      boolean identifiersOnly, int incompleteListSize)
             throws
             ServerException {
@@ -274,11 +287,11 @@ public class Responder implements Closeable {
             checkMetadataPrefix(metadataPrefix);
             ListProvider<CachedContent> provider = new RecordListProvider(
                     m_cache, incompleteListSize, identifiersOnly, fromDate,
-                    untilDate, metadataPrefix, set);
+                    untilDate, metadataPrefix, sets);
             return m_sessionManager.list(provider);
         } else {
             if (from != null || until != null || metadataPrefix != null
-                    || set != null) {
+                    || sets != null) {
                 throw new BadArgumentException("the resumptionToken argument may only be specified by itself");
             }
             return m_sessionManager.getResponseData(resumptionToken);
@@ -331,7 +344,7 @@ public class Responder implements Closeable {
      * @param metadataPrefix  specifies that records should be returned only if the metadata
      *                        format matching the supplied metadataPrefix is available (or
      *                        has been deleted).
-     * @param set             optional argument with a setSpec value, which specifies set
+     * @param sets             optional argument with a setSpec value, which specifies set
      *                        criteria for selective harvesting.
      * @param resumptionToken exclusive argument with a value that is the flow control token
      *                        returned by a previous ListIdentifiers request that issued an
@@ -349,21 +362,21 @@ public class Responder implements Closeable {
      * @throws ServerException                  if a low-level (non-protocol) error occurred.
      */
     public ResponseData listRecords(String from, String until,
-                                    String metadataPrefix, String set, String resumptionToken)
+                                    String metadataPrefix, String[] sets, String resumptionToken)
             throws
             ServerException {
 
         if (logger.isDebugEnabled()) {
             logger.debug(String.format("Entered listRecords(%s, %s, %s, %s, %s)",
-                    q(from), q(until), q(metadataPrefix), q(set), q(resumptionToken)));
+                    q(from), q(until), q(metadataPrefix), q(sets), q(resumptionToken)));
         }
         try {
-            return listRecords(from, until, metadataPrefix, set,
+            return listRecords(from, until, metadataPrefix, sets,
                     resumptionToken, false, m_incompleteRecordListSize);
         } finally {
             if (logger.isDebugEnabled()) {
                 logger.debug(String.format("Exiting listRecords(%s, %s, %s, %s, %s)",
-                        q(from), q(until), q(metadataPrefix), q(set), q(resumptionToken)));
+                        q(from), q(until), q(metadataPrefix), q(sets), q(resumptionToken)));
             }
         }
     }

--- a/src/test/java/proai/ResponderTestIT.java
+++ b/src/test/java/proai/ResponderTestIT.java
@@ -195,10 +195,10 @@ public class ResponderTestIT {
         try {
             if (identifiers) {
                 which = "Identifiers";
-                data = m_responder.listIdentifiers(from, until, prefix, set, null);
+                data = m_responder.listIdentifiers(from, until, prefix, new String[]{set}, null);
             } else {
                 which = "Records";
-                data = m_responder.listRecords(from, until, prefix, set, null);
+                data = m_responder.listRecords(from, until, prefix, new String[]{set}, null);
             }
             if (m_print)
                 printResult("list" + which + "(" + from + ", " + until + ", " + prefix + ", " + set + ", null)", data);


### PR DESCRIPTION
Although the OAI-PMH specification doesn't describe it, this
implementation allows for multiple set-parameters to be present in the
query. All queried setSpecs need to present on a record to match the
query.

The request-Element of the response echoes all queried sets in the
set-Attribute in the form of a comma separated list, e.g.:

<request verb="ListIdentifiers" metadataPrefix="oai_dc"
         set="status-type:publishedVersion, ddc:550">
http://localhost:8081/oai
</request>